### PR TITLE
Magento 2.2.0 compatibility

### DIFF
--- a/Plugin/Signature.php
+++ b/Plugin/Signature.php
@@ -24,19 +24,17 @@ class Signature
 
     /**
      * @param ScopeInterface $subject
-     * @param \Closure $proceed
+     * @param string $baseUrl
      * @param string $type
      * @param null $secure
      * @return string
      */
-    public function aroundGetBaseUrl(
+    public function afterGetBaseUrl(
         ScopeInterface $subject,
-        \Closure $proceed,
+        $baseUrl,
         $type = UrlInterface::URL_TYPE_LINK,
         $secure = null
     ) {
-        $baseUrl = $proceed($type, $secure);
-        
         switch ($type) {
             case UrlInterface::URL_TYPE_STATIC:
                 if ($this->config->isStaticEnabled()) {

--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@ With Absolute CacheBust for Magento 2 you can ensure your customers are viewing 
 This extension can be used with or without a CDN, and will also bust local versions of assets in your customers web browser cache.
 Find more information at https://abscom.co/cachebust.
 
+# Version Compatibility
+
+- For Magento 2.2.x please use version 3.x.x of this module.
+- For earlier Magento versions, please use version 2.x.x of this module.
+
 # Installation
 The best way to add the extension is via composer.
 

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "absolute/magento2-cache-bust",
     "description": "Absolute Commerce Cache Bust extension for Magento 2",
     "type": "magento2-module",
-    "version": "2.3.3",
+    "version": "3.0.0",
     "license": "proprietary",
     "autoload": {
         "files": [

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -6,5 +6,5 @@
  -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Absolute_CacheBust" setup_version="2.3.3" />
+    <module name="Absolute_CacheBust" setup_version="3.0.0" />
 </config>


### PR DESCRIPTION
Updated Plugin from aroundGetBaseUrl to afterGetBaseUrl to match vanilla Magento 2.2.0 updates (backward incompatible breaking change)