### PR TITLE
Magento 2.4.6 compatiblity

### DIFF
--- a/Console/Command/AllCommand.php
+++ b/Console/Command/AllCommand.php
@@ -16,7 +16,7 @@ class AllCommand extends CommandAbstract
     protected function configure()
     {
         parent::configure();
-        
+
         $this
             ->setName(self::COMMAND_NAMESPACE . 'all')
             ->setDescription('Bust All URLs.');
@@ -25,11 +25,12 @@ class AllCommand extends CommandAbstract
     /**
      * @param InputInterface $input
      * @param OutputInterface $output
-     * @return null
+     * @return int
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $this->cacheBust->bustAll();
         $output->writeln('<info>All URLs cache busted successfully.</info>');
+        return 0;
     }
 }

--- a/Console/Command/MediaCommand.php
+++ b/Console/Command/MediaCommand.php
@@ -16,7 +16,7 @@ class MediaCommand extends CommandAbstract
     protected function configure()
     {
         parent::configure();
-        
+
         $this
             ->setName(self::COMMAND_NAMESPACE . 'media')
             ->setDescription('Bust Media URLs.');
@@ -25,11 +25,12 @@ class MediaCommand extends CommandAbstract
     /**
      * @param InputInterface $input
      * @param OutputInterface $output
-     * @return null
+     * @return int
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $this->cacheBust->bustMedia();
         $output->writeln('<info>Media URLs cache busted successfully.</info>');
+        return 0;
     }
 }

--- a/Console/Command/StaticCommand.php
+++ b/Console/Command/StaticCommand.php
@@ -16,7 +16,7 @@ class StaticCommand extends CommandAbstract
     protected function configure()
     {
         parent::configure();
-        
+
         $this
             ->setName(self::COMMAND_NAMESPACE . 'static')
             ->setDescription('Bust Static URLs.');
@@ -25,11 +25,12 @@ class StaticCommand extends CommandAbstract
     /**
      * @param InputInterface $input
      * @param OutputInterface $output
-     * @return null
+     * @return int
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $this->cacheBust->bustStatic();
         $output->writeln('<info>Static URLs cache busted successfully.</info>');
+        return 0;
     }
 }

--- a/Update/UpdateFeed.php
+++ b/Update/UpdateFeed.php
@@ -44,7 +44,7 @@ class UpdateFeed extends MagentoFeed
         );
         $curl->addOption(CURLOPT_FOLLOWLOCATION, true);
         
-        $curl->write(\Zend_Http_Client::GET, $this->getFeedUrl(), '1.0');
+        $curl->write('GET', $this->getFeedUrl(), '1.0');
         $data = $curl->read();
         $curl->close();
         

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,6 @@
     "name": "absolute/magento2-cache-bust",
     "description": "Absolute Commerce Cache Bust extension for Magento 2",
     "type": "magento2-module",
-    "version": "3.1.2",
     "license": "proprietary",
     "autoload": {
         "files": [


### PR DESCRIPTION
Fix return value of commands:
```
Return value of "Absolute\CacheBust\Console\Command\StaticCommand\Interceptor::execute()" must be of the type int, "null" returned.
```

Fix missing reference to `Zend_Http_Client::GET`